### PR TITLE
Compatibility fix for OJS 3.1.1.x and earlier

### DIFF
--- a/EditorialBioHandler.inc.php
+++ b/EditorialBioHandler.inc.php
@@ -31,7 +31,13 @@ class EditorialBioHandler extends Handler {
 			// This user is an editor and has a biography
 			$templateMgr = TemplateManager::getManager($request);
 			$templateMgr->assign('editor', $editor);
-			$templateMgr->display($plugin->getTemplateResource('frontend/pages/aboutEditorialTeamBio.tpl'));
+			if (method_exists($plugin, 'getTemplateResource')) {
+				// OJS 3.1.2+
+				$templateMgr->display($plugin->getTemplateResource('frontend/pages/aboutEditorialTeamBio.tpl'));
+			} else {
+				// before OJS 3.1.2
+				$templateMgr->display($plugin->getTemplatePath() . 'frontend/pages/aboutEditorialTeamBio.tpl');
+			}
 		} else {
 			// Don't trust other users biographies
 			$dispatcher = $request->getDispatcher();


### PR DESCRIPTION
Testing for existence of getTemplateResource method and adding fallback for earlier versions. Tested in 3.1.1-4, 3.1.2-something, and 3.2(ish).